### PR TITLE
Upgrade to Zig 0.15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
           version: latest
       - run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-              sudo apt-get install libasound2-dev
+              sudo apt-get update -y
+              sudo apt-get install -y libasound2t64 libasound2-dev
           fi
         shell: bash
       - run: |
@@ -27,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.13.0
+          version: latest
       - run: zig fmt --check .

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "rtmidi_z",
+    .name = .rtmidi_z,
     .version = "6.0.0+53809fc",
+    .fingerprint = 0xcd89fd462f75e660, // Changing this has security and trust implications.
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/c.zig
+++ b/c.zig
@@ -1,4 +1,4 @@
-pub const CCallback = fn (f64, ?[*]const u8, usize, ?*anyopaque) callconv(.C) void;
+pub const CCallback = fn (f64, ?[*]const u8, usize, ?*anyopaque) callconv(.c) void;
 
 pub const Api = enum(c_int) { unspecified, macosx_core, linux_alsa, unix_jack, windows_mm, rtmidi_dummy, web_midi_api, windows_uwp, android, num };
 


### PR DESCRIPTION
Making the project compatible with Zig 0.15 projects. Outside of just some API migrations, there are a few things to call out.

  1. The library needs to link against LLVM. The self-hosted x86 backend did not work
  2. Added `.fingerprint` in the `build.zig.zon`. This value probably needs to change when merged in since it's pinned to my repo
  3. Updated the workflow files to use the latest zig