### PR TITLE
fix `zig build` caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,7 +12,7 @@
     .dependencies = .{
         .upstream = .{
             .url = "https://github.com/thestk/rtmidi/archive/53809fc1869a9789c4631a11081c1840b6db1527.tar.gz",
-            .hash = "12201253fb51b1c24c5dbbc2d1ea6f752289dec30ae992bc35123b2da6c572d4899b",
+            .hash = "N-V-__8AABKxDgASU_tRscJMXbvC0epvdSKJ3sMK6ZK8NRI7",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,7 @@
     .name = .rtmidi_z,
     .version = "6.0.0+53809fc",
     .fingerprint = 0xcd89fd462f75e660, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.15.2",
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
Hi, thanks for the library! I have a project that uses it, but my project spends an extra second every time I run it (`zig build run`) re-fetching the "upstream" dependency. (thestk/rtmidi)

With this change, the cache now works properly and my project runs instantly. (my `zig version` is `0.15.2`)

More info in commit messages and here: https://ziggit.dev/t/zig-build-not-caching/14193
